### PR TITLE
Add JPMS support using Automatic-Module-Name

### DIFF
--- a/src/conf/MANIFEST.MF
+++ b/src/conf/MANIFEST.MF
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 Export-Package: org.apache.commons.logging;version="1.2.0",org.apache.
  commons.logging.impl;version="1.2.0"
+Automatic-Module-Name: org.apache.commons.logging
 Implementation-Title: Commons Logging
 Implementation-Vendor: The Apache Software Foundation
 Implementation-Vendor-Id: org.apache


### PR DESCRIPTION
Understandably this project is unmaintained and pointless for a long time. However, many libraries, especially proprietary ones, still make use of `commons-logging`.

It is ideal if we can simply reserve the `org.apache.commons.logging` module name so that it is safe to publish these artifacts, and this artifact doesn't prevent migration of ancient projects to JPMS.