### PR TITLE
mark loggers for Avalon and Lumberjack as deprecated

### DIFF
--- a/src/main/java/org/apache/commons/logging/impl/AvalonLogger.java
+++ b/src/main/java/org/apache/commons/logging/impl/AvalonLogger.java
@@ -48,7 +48,10 @@ import org.apache.commons.logging.Log;
  * commons-logging, but this never actually worked (a NullPointerException would
  * be thrown as soon as the deserialized object was used), so removing this marker
  * is not considered to be an incompatible change.
+ * 
+ * @deprecated Due to be removed as the Apache Avalon Project no longer exists
  */
+@Deprecated
 public class AvalonLogger implements Log {
 
     /** Ancestral Avalon logger. */

--- a/src/main/java/org/apache/commons/logging/impl/AvalonLogger.java
+++ b/src/main/java/org/apache/commons/logging/impl/AvalonLogger.java
@@ -49,7 +49,7 @@ import org.apache.commons.logging.Log;
  * be thrown as soon as the deserialized object was used), so removing this marker
  * is not considered to be an incompatible change.
  * 
- * @deprecated Due to be removed as the Apache Avalon Project no longer exists
+ * @deprecated Scheduled for removal because the Apache Avalon Project has been discontinued.
  */
 @Deprecated
 public class AvalonLogger implements Log {

--- a/src/main/java/org/apache/commons/logging/impl/Jdk13LumberjackLogger.java
+++ b/src/main/java/org/apache/commons/logging/impl/Jdk13LumberjackLogger.java
@@ -33,7 +33,7 @@ import org.apache.commons.logging.Log;
  * available in SourceForge's Lumberjack for JDKs prior to 1.4.
  *
  * @since 1.1
- * @deprecated Due to be removed as Lumberjack is no longer maintained
+ * @deprecated Scheduled for removal because the Apache Avalon Project has been discontinued.
  */
 @Deprecated
 public class Jdk13LumberjackLogger implements Log, Serializable {

--- a/src/main/java/org/apache/commons/logging/impl/Jdk13LumberjackLogger.java
+++ b/src/main/java/org/apache/commons/logging/impl/Jdk13LumberjackLogger.java
@@ -33,7 +33,9 @@ import org.apache.commons.logging.Log;
  * available in SourceForge's Lumberjack for JDKs prior to 1.4.
  *
  * @since 1.1
+ * @deprecated Due to be removed as Lumberjack is no longer maintained
  */
+@Deprecated
 public class Jdk13LumberjackLogger implements Log, Serializable {
 
     /** Serializable version identifier. */

--- a/src/main/java/org/apache/commons/logging/impl/LogKitLogger.java
+++ b/src/main/java/org/apache/commons/logging/impl/LogKitLogger.java
@@ -30,7 +30,10 @@ import org.apache.commons.logging.Log;
  * {@code LogKit} accepts only {@code String} messages.
  * Therefore, this implementation converts object messages into strings
  * by called their {@code toString()} method before logging them.
+ * 
+ * @deprecated Due to be removed as the Apache Avalon Project no longer exists
  */
+@Deprecated
 public class LogKitLogger implements Log, Serializable {
 
     /** Serializable version identifier. */

--- a/src/main/java/org/apache/commons/logging/impl/LogKitLogger.java
+++ b/src/main/java/org/apache/commons/logging/impl/LogKitLogger.java
@@ -31,7 +31,7 @@ import org.apache.commons.logging.Log;
  * Therefore, this implementation converts object messages into strings
  * by called their {@code toString()} method before logging them.
  * 
- * @deprecated Due to be removed as the Apache Avalon Project no longer exists
+ * @deprecated Scheduled for removal because the Apache Avalon Project has been discontinued.
  */
 @Deprecated
 public class LogKitLogger implements Log, Serializable {


### PR DESCRIPTION
Ideally #26 would have been merged years ago but as there seems to be a desire to keep these loggers in place for now at least mark them as being deprecated. Then perhaps remove them completely after the next release.