### PR TITLE
Set `java.logging` as optional module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,26 @@ under the License.
       </plugin>
 
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <configuration>
+              <module>
+                <moduleInfo>
+                  <requires>
+                    static java.logging;
+                    *;
+                  </requires>
+                </moduleInfo>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <!--
           - Many of JCL's tests use tricky techniques to place the generated
           - JCL jarfiles on the classpath in various configurations. This means


### PR DESCRIPTION
Commons Logging has a fallback simple logger that is used if the `java.util.logging` package is not present.

Originally this only could happen with Java 1.3, but sinc Java 9 the user can disable the `java.logging` JPMS module. Commons Logging will work anyway.

This PR slightly modifies the inherited Moditect configuration to add a `static` (i.e. optional) modifier to the `java.logging` module.

**Remark**: the artifacts with classifier `api` and `adapters` will not have a JPMS module descriptor. I think that is fine: they are meant for servlet application and servlet containers currently do not run on the module path.