### PR TITLE
Upgrade `log4j-api` to version `2.23.1`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@ under the License.
     <commons.failsafe.version>3.2.1</commons.failsafe.version>
     <!-- Allow default test run order to be changed -->
     <failsafe.runorder>filesystem</failsafe.runorder>
-    <log4j2.version>2.22.1</log4j2.version>
+    <log4j2.version>2.23.1</log4j2.version>
     <logback.version>1.3.12</logback.version>
     <slf4j.version>2.0.12</slf4j.version>
     <findsecbugs.version>1.13.0</findsecbugs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -434,6 +434,33 @@ under the License.
               </plugins>
           </configuration>
       </plugin>
+
+      <!--
+        ~ Ban Commons Logging clones
+        -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>ban-jcl-clones</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.slf4j:jcl-over-slf4j</exclude>
+                    <exclude>org.springframework:spring-jcl</exclude>
+                  </excludes>
+                </bannedDependencies>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 
@@ -491,6 +518,13 @@ under the License.
       <artifactId>log4j-core-test</artifactId>
       <version>${log4j2.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <!-- Commons Logging clone -->
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jcl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Since `log4j-core-test` version 2.23.1 depends on `spring-jcl`, the automatic Dependabot update didn't succeed.

This PR bans all `commons-logging` clones from ending up on the classpath and bumps the version of `log4j-api` to 2.23.1.