### PR TITLE
Remove deprecated dependencies to satisfy security scanners

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@ under the License.
     <dependency>
       <groupId>avalon-framework</groupId>
       <artifactId>avalon-framework</artifactId>
-      <version>4.1.5</version>
+      <version>${avalon.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -600,7 +600,7 @@ under the License.
     <dependency>
       <groupId>logkit</groupId>
       <artifactId>logkit</artifactId>
-      <version>2.0</version>
+      <version>${logkit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -725,8 +725,10 @@ under the License.
     <commons.failsafe.version>3.2.1</commons.failsafe.version>
     <!-- Allow default test run order to be changed -->
     <failsafe.runorder>filesystem</failsafe.runorder>
+    <avalon.version>4.1.5</avalon.version>
     <log4j2.version>2.23.1</log4j2.version>
     <logback.version>1.3.14</logback.version>
+    <logkit.version>2.0</logkit.version>
     <slf4j.version>2.0.12</slf4j.version>
     <findsecbugs.version>1.13.0</findsecbugs.version>
     <commons.osgi.import>
@@ -741,6 +743,45 @@ under the License.
     <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
   </properties>
 
+  <profiles>
+    <!--
+      ~ Overrides the Animal Sniffer profile from the parent POM.
+    -->
+    <profile>
+      <id>animal-sniffer</id>
+      <activation>
+        <jdk>(,9)</jdk>
+        <file>
+          <missing>src/site/resources/profile.noanimal</missing>
+        </file>
+      </activation>
+
+      <build>
+        <plugins>
+
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>animal-sniffer-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>checkAPIcompatibility</id>
+                <configuration>
+                  <!-- Ignores the absence of these classes from the compile path -->
+                  <ignores>
+                    <ignore>org.apache.avalon.framework.logger.*</ignore>
+                    <ignore>org.apache.log.*</ignore>
+                    <ignore>org.apache.log4j.*</ignore>
+                  </ignores>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+        </plugins>
+      </build>
+
+    </profile>
+  </profiles>
   <developers>
     <developer>
       <id>baliuka</id>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,49 @@ under the License.
     <plugins>
 
       <!--
+        ~ Adds a directory containing "dummy" classes.
+        ~
+        ~ These are simplified versions of LogKit, Avalon and Log4j 1.x classes used only at compile-time.
+        ~ This should be enough to trick primitive security scanners that complain about the presence of a deprecated/unmaintained
+        ~ library in the POM file.
+        -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-dummy-sources</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <sources>
+                <source>src/main/dummy</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <!-- Prevents the compilation of dummy classes -->
+              <implicit>none</implicit>
+              <includes>
+                <include>org/apache/commons/logging/**</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!--
         - We want to create four jarfiles from this project: normal, tests, api
         - and adapters. The first two are handled by the normal jar:jar and
         - jar:test-jar targets.
@@ -66,6 +109,19 @@ under the License.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
+
+          <execution>
+            <id>default-jar</id>
+            <configuration>
+              <!--
+                ~ Failsafe to prevent the inclusion of dummy classes even if they end up being compiled.
+                -->
+              <includes>
+                <include>org/apache/commons/logging/**</include>
+              </includes>
+            </configuration>
+          </execution>
+
           <execution>
             <!--
               - The custom test framework requires the unit test code to be
@@ -202,6 +258,11 @@ under the License.
                   </requires>
                 </moduleInfo>
               </module>
+              <!-- Ignores the dependencies on dummy classes for the LogKit, Avalon and Log4j 1.x `Log` implementations -->
+              <jdepsExtraArgs>
+                <arg>--ignore-missing-deps</arg>
+                <arg>--multi-release=9</arg>
+              </jdepsExtraArgs>
             </configuration>
           </execution>
         </executions>
@@ -522,13 +583,13 @@ under the License.
       <groupId>avalon-framework</groupId>
       <artifactId>avalon-framework</artifactId>
       <version>4.1.5</version>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
       <version>${log4j2.version}</version>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -540,7 +601,7 @@ under the License.
       <groupId>logkit</groupId>
       <artifactId>logkit</artifactId>
       <version>2.0</version>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/dummy/org/apache/avalon/framework/logger/Logger.java
+++ b/src/main/dummy/org/apache/avalon/framework/logger/Logger.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.avalon.framework.logger;
+
+/**
+ * This is a dummy class used to compile {@link org.apache.commons.logging.impl.AvalonLogger}, without depending on
+ * the deprecated Avalon library.
+ */
+public interface Logger {
+    void debug(String var1);
+
+    void debug(String var1, Throwable var2);
+
+    boolean isDebugEnabled();
+
+    void info(String var1);
+
+    void info(String var1, Throwable var2);
+
+    boolean isInfoEnabled();
+
+    void warn(String var1);
+
+    void warn(String var1, Throwable var2);
+
+    boolean isWarnEnabled();
+
+    void error(String var1);
+
+    void error(String var1, Throwable var2);
+
+    boolean isErrorEnabled();
+
+    void fatalError(String var1);
+
+    void fatalError(String var1, Throwable var2);
+
+    boolean isFatalErrorEnabled();
+
+    Logger getChildLogger(String var1);
+}

--- a/src/main/dummy/org/apache/log/Hierarchy.java
+++ b/src/main/dummy/org/apache/log/Hierarchy.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.log;
+
+/**
+ * This is a dummy class used to compile {@link org.apache.commons.logging.impl.LogKitLogger}, without depending on
+ * the deprecated LogKit library.
+ */
+public class Hierarchy {
+
+    public static Hierarchy getDefaultHierarchy() {
+        return null;
+    }
+
+    public Logger getLoggerFor(String ignored) {
+        return null;
+    }
+
+}

--- a/src/main/dummy/org/apache/log/Logger.java
+++ b/src/main/dummy/org/apache/log/Logger.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.log;
+
+/**
+ * This is a dummy class used to compile {@link org.apache.commons.logging.impl.LogKitLogger}, without depending on the
+ * deprecated LogKit library.
+ */
+public class Logger {
+
+    public final boolean isDebugEnabled() {
+        return false;
+    }
+
+    public final void debug(final String message, final Throwable throwable) {
+    }
+
+    public final void debug(final String message) {
+    }
+
+    public final boolean isInfoEnabled() {
+        return false;
+    }
+
+    public final void info(final String message, final Throwable throwable) {
+    }
+
+    public final void info(final String message) {
+    }
+
+    public final boolean isWarnEnabled() {
+        return false;
+    }
+
+    public final void warn(final String message, final Throwable throwable) {
+    }
+
+    public final void warn(final String message) {
+    }
+
+    public final boolean isErrorEnabled() {
+        return false;
+    }
+
+    public final void error(final String message, final Throwable throwable) {
+    }
+
+    public final void error(final String message) {
+
+    }
+
+    public final boolean isFatalErrorEnabled() {
+        return false;
+    }
+
+    public final void fatalError(final String message, final Throwable throwable) {
+    }
+
+    public final void fatalError(final String message) {
+    }
+
+}

--- a/src/main/dummy/org/apache/log4j/Category.java
+++ b/src/main/dummy/org/apache/log4j/Category.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.log4j;
+
+/**
+ * This is a dummy class used to compile {@link org.apache.commons.logging.impl.Log4JLogger}, without depending on the
+ * deprecated Log4j 1.x library.
+ */
+public class Category {
+
+    public final String getName() {
+        return null;
+    }
+
+    public void log(final String fqcn, final Priority priority, final Object message, final Throwable t) {
+    }
+
+    public boolean isEnabledFor(final Priority level) {
+        return false;
+    }
+}

--- a/src/main/dummy/org/apache/log4j/Level.java
+++ b/src/main/dummy/org/apache/log4j/Level.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.log4j;
+
+import java.io.Serializable;
+
+/**
+ * This is a dummy class used to compile {@link org.apache.commons.logging.impl.Log4JLogger}, without depending on the
+ * deprecated Log4j 1.x library.
+ */
+public class Level extends Priority implements Serializable {
+    public static final Level FATAL = null;
+    public static final Level ERROR = null;
+    public static final Level WARN = null;
+    public static final Level INFO = null;
+    public static final Level DEBUG = null;
+    public static final Level TRACE = null;
+}

--- a/src/main/dummy/org/apache/log4j/Logger.java
+++ b/src/main/dummy/org/apache/log4j/Logger.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.log4j;
+
+/**
+ * This is a dummy class used to compile {@link org.apache.commons.logging.impl.Log4JLogger}, without depending on the
+ * deprecated Log4j 1.x library.
+ */
+public class Logger extends Category {
+
+    public static Logger getLogger(final String name) {
+        return null;
+    }
+}

--- a/src/main/dummy/org/apache/log4j/Priority.java
+++ b/src/main/dummy/org/apache/log4j/Priority.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.log4j;
+
+/**
+ * This is a dummy class used to compile {@link org.apache.commons.logging.impl.Log4JLogger}, without depending on the
+ * deprecated Log4j 1.x library.
+ */
+public class Priority {
+}

--- a/src/main/java/org/apache/commons/logging/impl/Log4JLogger.java
+++ b/src/main/java/org/apache/commons/logging/impl/Log4JLogger.java
@@ -236,7 +236,7 @@ public class Log4JLogger implements Log, Serializable {
      */
     @Override
     public boolean isDebugEnabled() {
-        return getLogger().isDebugEnabled();
+        return getLogger().isEnabledFor(Level.DEBUG);
     }
 
     /**
@@ -260,7 +260,7 @@ public class Log4JLogger implements Log, Serializable {
      */
     @Override
     public boolean isInfoEnabled() {
-        return getLogger().isInfoEnabled();
+        return getLogger().isEnabledFor(Level.INFO);
     }
 
     /**


### PR DESCRIPTION
This is a PoC on how to remove deprecated libraries from the POM file (or move them to the `test` scope) to appease some primitive security scanners.

The trick is to extract classes/methods from the Avalon, LogKit and Log4j 1.x libraries that are used in the Commons Logging code and put them in an additional source code directory `src/main/dummy`.

**Remark:** The source files in `src/main/dummy` are **not** included in the any Commons Logging artifact. They are only used by the compiler to include the correct signatures in the class files.

## Motivation

From a developer perspective the change is useless and the new artifacts should be **identical** to those before this change (except the embedded `pom.xml`, `module-info.class` and the aesthetic change in `Log4JLog`).

However many developers struggle to explain to their security experts that having `log4j:log4j` somewhere in a POM file is not a problem (cf. [many questions on SO](https://stackoverflow.com/search?q=maven+download+log4j)). This is also in line with #231. 