### PR TITLE
[LOGGING-190] Add OSGi metadata to enable Service Loader Mediator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,6 +510,26 @@ under the License.
       </plugin>
 
     </plugins>
+
+    <pluginManagement>
+      <plugins>
+
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <configuration>
+            <instructions>
+              <Require-Capability><![CDATA[ 
+                osgi.extender;filter:="(&(osgi.extender=osgi.serviceloader.processor)(version>=1.0.0)(!(version>=2.0.0)))";resolution:=optional,
+                osgi.serviceloader;filter:="(osgi.serviceloader=org.apache.commons.logging.LogFactory)";osgi.serviceloader="org.apache.commons.logging.LogFactory";resolution:=optional;cardinality:=multiple
+              ]]></Require-Capability>
+            </instructions>
+          </configuration>
+        </plugin>
+
+      </plugins>
+    </pluginManagement>
+
   </build>
 
   <dependencies>


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/LOGGING-190.

In contrast to the initial proposal at the mention issue I also added the directives `resolution:=optional;cardinality:=multiple` to allow the bundle to resolve without any and to wire to multiple providers if available.

@jcompagner please verify that this works for your case. You can simply build the jar running maven from the project root:
```
mvn --show-version --batch-mode --no-transfer-progress -Ddoclint=none
```