### PR TITLE
[LOGGING-198] Add proper OSGi uses to export package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@ under the License.
     <logback.version>1.3.14</logback.version>
     <slf4j.version>2.0.16</slf4j.version>
     <findsecbugs.version>1.13.0</findsecbugs.version>
+    <!-- Workaround due to https://github.com/apache/commons-parent/pull/581-->
+    <commons.osgi.export>
+      org.apache.commons.logging;-noimport:=true,
+      org.apache.commons.logging.impl;-noimport:=true;uses:="javax.servlet,org.apache.avalon.framework.logger,org.apache.commons.logging,org.apache.log,org.apache.log4j"
+    </commons.osgi.export>
     <commons.osgi.import>
       javax.servlet;version="[2.1.0, 5.0.0)";resolution:=optional,
       org.apache.avalon.framework.logger;version="[4.1.3, 4.1.5]";resolution:=optional,


### PR DESCRIPTION
Currently there are no use clauses on the export package header, this can lead to classloading problems.

This now adds the appropriate use clause to the export header, due to a bug in commons-parent this currently can not be calculated automatically.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
