### PR TITLE
Adapt to jakarta.servlet* to prevent issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,15 +174,15 @@ under the License.
         </configuration>
       </plugin>
       <plugin>
-	<groupId>com.github.siom79.japicmp</groupId>
-	<artifactId>japicmp-maven-plugin</artifactId>
-	<configuration>
-         <parameter>
-           <excludes>
-             <exclude>org.apache.commons.logging.impl.ServletContextCleaner</exclude>
-	   </excludes>
-         </parameter>
-	</configuration>
+        <groupId>com.github.siom79.japicmp</groupId>
+		<artifactId>japicmp-maven-plugin</artifactId>
+		<configuration>
+		  <parameter>
+            <excludes>
+              <exclude>org.apache.commons.logging.impl.ServletContextCleaner</exclude>
+	        </excludes>
+          </parameter>
+		</configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -585,7 +585,7 @@ under the License.
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.0.0</version>
+      <version>6.1.0</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@ under the License.
     <slf4j.version>2.0.17</slf4j.version>
     <findsecbugs.version>1.14.0</findsecbugs.version>
     <commons.osgi.import>
-      javax.servlet;version="[2.1.0, 5.0.0)";resolution:=optional,
+      jakarta.servlet;version="[4.0.2, 7.0.0)";resolution:=optional,
       org.apache.avalon.framework.logger;version="[4.1.3, 4.1.5]";resolution:=optional,
       org.apache.log;version="[1.0.1, 1.0.1]";resolution:=optional,
       org.apache.log4j;version="[1.2.15, 2.0.0)";resolution:=optional,
@@ -174,6 +174,17 @@ under the License.
         </configuration>
       </plugin>
       <plugin>
+	<groupId>com.github.siom79.japicmp</groupId>
+	<artifactId>japicmp-maven-plugin</artifactId>
+	<configuration>
+         <parameter>
+           <excludes>
+             <exclude>org.apache.commons.logging.impl.ServletContextCleaner</exclude>
+	   </excludes>
+         </parameter>
+	</configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
@@ -274,7 +285,7 @@ under the License.
                 <log4j12>${org.apache.logging.log4j:log4j-1.2-api:jar}</log4j12>
                 <log4j-api>${org.apache.logging.log4j:log4j-api:jar}</log4j-api>
                 <logkit>${logkit:logkit:jar}</logkit>
-                <servlet-api>${javax.servlet:javax.servlet-api:jar}</servlet-api>
+                <servlet-api>${jakarta.servlet:jakarta.servlet-api:jar}</servlet-api>
                 <commons-logging>target/${project.build.finalName}.jar</commons-logging>
                 <commons-logging-api>target/${project.build.finalName}-api.jar</commons-logging-api>
                 <commons-logging-adapters>target/${project.build.finalName}-adapters.jar</commons-logging-adapters>
@@ -572,9 +583,9 @@ under the License.
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
@@ -810,3 +821,4 @@ under the License.
     </contributor>
   </contributors>
 </project>
+

--- a/src/main/java/org/apache/commons/logging/impl/ServletContextCleaner.java
+++ b/src/main/java/org/apache/commons/logging/impl/ServletContextCleaner.java
@@ -20,8 +20,8 @@ package org.apache.commons.logging.impl;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import javax.servlet.ServletContextEvent;
-import javax.servlet.ServletContextListener;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
 
 import org.apache.commons.logging.LogFactory;
 
@@ -143,3 +143,4 @@ public class ServletContextCleaner implements ServletContextListener {
         // do nothing
     }
 }
+


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

In newer versions of commons-logging the `org.apache.commons.logging.impl.ServletContextCleaner` is still `javax.servlet*` compatible. Versions 1.3.x though are widely used in `Tomcat 10/ TomEE 10.1.x` which are `jakarta.servlet.*` compatible, for example latest versions of TomEE 10.1.x plume include commons-logging 1.3.5 in the tomee/lib folder subject of the common classloader.
Thus if someone uses this `ServletContextCleaner` will result in 
```
java.lang.NoClassDefFoundError: javax/servlet/ServletContextListener
		...
		at org.apache.catalina.startup.Bootstrap.start(Bootstrap.java:345)
		at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:476)
	Caused by: java.lang.ClassNotFoundException: javax.servlet.ServletContextListener
		at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1353)
		at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1165)
		... 51 more
```

The PR addresses this issue. Apart from adjusting `org.apache.commons.logging.impl.ServletContextCleaner` the `japicmp-maven-plugin` is tuned to exclude this class from the checks in order not to signal for incompatibility because of the javax->jakarta modification.
The existing `BasicServletTestCase` covers this so new test is not added.

The issue is described also in [LOGGING-199](https://issues.apache.org/jira/browse/LOGGING-199)

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
